### PR TITLE
Update version of org.jboss.spec.jboss.javaee.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <version.logback-classic>1.0.9</version.logback-classic>
 
         <!-- Versions of JBoss projects -->
-        <version.org.jboss.spec.jboss.javaee.6.0>3.0.2.Final-redhat-4</version.org.jboss.spec.jboss.javaee.6.0>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.2.Final-redhat-13</version.org.jboss.spec.jboss.javaee.6.0>
 
         <!-- Override EAP 6.1.1 shrinkwrap version -->
         <version.org.jboss.shrinkwrap.resolver>2.0.0</version.org.jboss.shrinkwrap.resolver>


### PR DESCRIPTION
- The new version matches the one in EAP 6.3.1.GA
- see https://github.com/jboss-developer/jboss-eap-boms/blob/6.3.1.GA/pom.xml#L54
